### PR TITLE
오치문 - AI 시대, IT 노동자의 미래 <걱정과 대책에 대하여>

### DIFF
--- a/speakers_list.json
+++ b/speakers_list.json
@@ -29,7 +29,7 @@
   },
   {
     "이름": "오치문",
-    "소속": "민주노총 화섬노조 카카오 크루유니언 부지회장",
+    "소속": "민주노총 화섬노조 카카오지회 부지회장",
     "주제": "AI 시대, IT 노동자의 미래 <걱정과 대책에 대하여>",
     "참조": "https://github.com/orbital-pet/NOANcon2025/issues/17#issuecomment-3218429937",
     "사진": "https://github.com/user-attachments/assets/0d2c3922-90a1-4ac5-b930-92541f502b2e"


### PR DESCRIPTION
# 오치문

<img width="200" alt="Image" src="https://github.com/user-attachments/assets/0d2c3922-90a1-4ac5-b930-92541f502b2e" />

### 약력
SW엔지니어
- 2010 ~ 2012.10 : 제너시스템즈 
- 2012.11 ~ 2014.09 : 다음커뮤니케이션
- 2014.10 ~ 2019.12 : 카카오
- 2019.12 ~ 현재 : 카카오엔터프라이즈

테크리드/매니저
- 2019.12 ~ 2023.9 : 카카오엔터프라이즈

노동조합 (크루유니언)
- 2018.10 ~ 2021.12 : 스태프
- 2022 ~ 2024 : 수석부지회장
- 2025 ~ 현재 : 부지회장

# 발표주제
- AI 시대, IT 노동자의 미래 <걱정과 대책에 대하여>

"AI 도구가 점점 업무 영역을 확대하고 있습니다. 
IT 노동자의 미래는 과연 어떻게 될까요? 
제가 걱정하는 이유는 무엇일까요?
또한 노동계에서는 이 문제를 어떻게 풀 수 있을까요?
노동자 관점에서 바라본 미래, 구조적인 문제와 한계, 해법에 대해 이야기 합니다."
