### PR TITLE
성동찬 - "CDC - 흐르는 데이터에 꼽은 빨대 이야기"

### DIFF
--- a/speakers_list.json
+++ b/speakers_list.json
@@ -201,5 +201,12 @@
     "주제": "LOADING...",
     "참조": "",
     "사진": "https://github.com/user-attachments/assets/83e71944-78d0-466c-b652-b5081f301eb2"
+  },
+  {
+    "이름": "성동찬",
+    "소속": "카카오뱅크",
+    "주제": "CDC - 흐르는 데이터에 꼽은 빨대 이야기",
+    "참조": "",
+    "사진": "https://github.com/user-attachments/assets/88021078-f527-4788-bb82-7e7767713b0d"
   }
 ]


### PR DESCRIPTION
# 성동찬

![Image](https://github.com/user-attachments/assets/88021078-f527-4788-bb82-7e7767713b0d)

## 직장

[카카오뱅크] 
- DBA 및 빅데이터 엔지니어로 근무
- 2016.05.01 ~ 현재 

[카카오]
- DBA
- 2012.12.01 ~ 2016.04.28

[티몬]
- DBA
- 2012.09.01 ~ 2012.10.30

[KTH]
- Software Engineer 및 DBA
- 2008.01.01 ~ 2012.08.31


## 학력
- 인하대학교 (2000.03 ~ 2008.02)
- 여의도 고등학교 (2000.03 ~ 2008.02)

## 대외 발표
- [Percona Live Online 2021](https://perconalive.sched.com/event/io4d)
- [삼성 오픈소스 컨퍼런스 2019](https://www.slideshare.net/slideshow/ss-183100083/183100083)
- [카카오 ifkakao2019](https://youtu.be/xscjEU3ZPLM)
- [마소콘2017](https://youtu.be/Z4dM6GBYO1M)
- [데이터야놀자2017](https://lee-monster.github.io/datayanolja2017/slide/2016/1-%ED%82%A4%EB%85%B8%ED%8A%B8/%ED%82%A4%EB%85%B8%ED%8A%B8-3-KakaoBank%20with%20opensource-%EC%84%B1%EB%8F%99%EC%B0%AC.pdf)
- [Naver Deview 2017](https://naver.me/FK5OmRn1)
- [KTH H3 2011](https://youtu.be/aVP0QOWEaFk)

## 사이트
- https://github.com/go-gywn
- https://github.com/gywndi
- https://gywn.blog/
- https://gywn.net/

## 집필도서
- MySQL 퍼포먼스 최적화
- MariaDB 실전 활용 노하우